### PR TITLE
Improve the performance reporting

### DIFF
--- a/July2024/main.mojo
+++ b/July2024/main.mojo
@@ -1,12 +1,16 @@
 from src import Matrix, Type, test_matmul, bench_matmul
 from algorithm.functional import vectorize, parallelize
 
-fn matmul[Type: DType, M: Int, N: Int, K: Int, //](inout res: Matrix[Type, M, N], a: Matrix[Type, M, K], b: Matrix[Type, K, N]):    
+
+fn matmul[
+    Type: DType, M: Int, N: Int, K: Int, //
+](inout res: Matrix[Type, M, N], a: Matrix[Type, M, K], b: Matrix[Type, K, N]):
     for m in range(M):
         for k in range(K):
             for n in range(N):
                 res[m, n] += a[m, k] * b[k, n]
 
+
 fn main() raises:
-    #test_matmul[matmul]()
+    # test_matmul[matmul]()
     bench_matmul[matmul]()

--- a/July2024/main.mojo
+++ b/July2024/main.mojo
@@ -8,5 +8,5 @@ fn matmul[Type: DType, M: Int, N: Int, K: Int, //](inout res: Matrix[Type, M, N]
                 res[m, n] += a[m, k] * b[k, n]
 
 fn main() raises:
-    test_matmul[matmul]()
+    #test_matmul[matmul]()
     bench_matmul[matmul]()

--- a/July2024/main.mojo
+++ b/July2024/main.mojo
@@ -1,4 +1,4 @@
-from src import Matrix, Type, test_matmul, bench_matmul
+from src import Matrix, test_matmul, bench_matmul
 from algorithm.functional import vectorize, parallelize
 
 
@@ -12,5 +12,5 @@ fn matmul[
 
 
 fn main() raises:
-    # test_matmul[matmul]()
+    test_matmul[matmul]()
     bench_matmul[matmul]()

--- a/July2024/src/__init__.mojo
+++ b/July2024/src/__init__.mojo
@@ -4,4 +4,6 @@ from .test import test_matmul, bench_matmul
 alias Type = DType.float16
 alias TestSize = 1024
 alias BenchIters = 16
-alias MatmulSignature = fn[Type: DType, M: Int, N: Int, K: Int, //](inout Matrix[Type, M, N], Matrix[Type, M, K], Matrix[Type, K, N]) -> None
+alias MatmulSignature = fn[Type: DType, M: Int, N: Int, K: Int, //] (
+    inout Matrix[Type, M, N], Matrix[Type, M, K], Matrix[Type, K, N]
+) -> None

--- a/July2024/src/__init__.mojo
+++ b/July2024/src/__init__.mojo
@@ -3,5 +3,5 @@ from .test import test_matmul, bench_matmul
 
 alias Type = DType.float16
 alias TestSize = 1024
-alias BenchIters = 512
+alias BenchIters = 16
 alias MatmulSignature = fn[Type: DType, M: Int, N: Int, K: Int, //](inout Matrix[Type, M, N], Matrix[Type, M, K], Matrix[Type, K, N]) -> None

--- a/July2024/src/__init__.mojo
+++ b/July2024/src/__init__.mojo
@@ -2,8 +2,7 @@ from .matrix import Matrix
 from .test import test_matmul, bench_matmul
 
 alias Type = DType.float16
-alias TestSize = 1024
-alias BenchIters = 16
+
 alias MatmulSignature = fn[Type: DType, M: Int, N: Int, K: Int, //] (
     inout Matrix[Type, M, N], Matrix[Type, M, K], Matrix[Type, K, N]
 ) -> None

--- a/July2024/src/matrix.mojo
+++ b/July2024/src/matrix.mojo
@@ -28,7 +28,7 @@ struct Matrix[Type: DType, Rows: Int, Cols: Int]:
         self.store[1](y, x, value)
 
     fn load[Nelts: Int](self, y: Int, x: Int) -> SIMD[Type, Nelts]:
-        return SIMD[size=Nelts].load(self.data, y * Cols + x)
+        return self.data.load[width=Nelts](y * Cols + x)
 
     fn store[Nelts: Int](inout self, y: Int, x: Int, value: SIMD[Type, Nelts]):
-        SIMD[size=Nelts].store(self.data, y * Cols + x, value)
+        self.data.store[width=Nelts](y * Cols + x, value)

--- a/July2024/src/matrix.mojo
+++ b/July2024/src/matrix.mojo
@@ -28,7 +28,7 @@ struct Matrix[Type: DType, Rows: Int, Cols: Int]:
         self.store[1](y, x, value)
 
     fn load[Nelts: Int](self, y: Int, x: Int) -> SIMD[Type, Nelts]:
-        return self.data.load[width=Nelts](y * Cols + x)
+        return SIMD[size=Nelts].load(self.data, y * Cols + x)
 
     fn store[Nelts: Int](inout self, y: Int, x: Int, value: SIMD[Type, Nelts]):
-        self.data.store[width=Nelts](y * Cols + x, value)
+        SIMD[size=Nelts].store(self.data, y * Cols + x, value)

--- a/July2024/src/test.mojo
+++ b/July2024/src/test.mojo
@@ -19,20 +19,31 @@ alias SCENARIOS = List(
 )
 
 
-alias dtypes_to_test = List(DType.int8, DType.int16, DType.int32, DType.int64,DType.float16, DType.float32, DType.float64)
+alias dtypes_to_test = List(
+    DType.int8,
+    DType.int16,
+    DType.int32,
+    DType.int64,
+    DType.float16,
+    DType.float32,
+    DType.float64,
+)
 
 
-fn basic_matmul[Type: DType, M: Int, N: Int, K: Int, //](inout res: Matrix[Type, M, N], a: Matrix[Type, M, K], b: Matrix[Type, K, N]):    
+fn basic_matmul[
+    Type: DType, M: Int, N: Int, K: Int, //
+](inout res: Matrix[Type, M, N], a: Matrix[Type, M, K], b: Matrix[Type, K, N]):
     for m in range(M):
         for k in range(K):
             for n in range(N):
                 res[m, n] += a[m, k] * b[k, n]
 
+
 fn test_matmul[MatMul: MatmulSignature]() raises:
     @parameter
     for i in range(len(SCENARIOS)):
         alias SCENARIO = SCENARIOS[i]
-        
+
         alias M = SCENARIO[0]
         alias N = SCENARIO[1]
         alias K = SCENARIO[2]
@@ -52,12 +63,11 @@ fn test_matmul[MatMul: MatmulSignature]() raises:
 
 
 fn bench_matmul[MatMul: MatmulSignature]() raises:
-
     @parameter
     for i in range(len(dtypes_to_test)):
+
         @parameter
-        for j in range(1, len(SCENARIOS)): # skip the first, not interesting
-    
+        for j in range(1, len(SCENARIOS)):  # skip the first, not interesting
             alias CurrentDType = dtypes_to_test[i]
             alias dimensions = SCENARIOS[j]
 
@@ -76,15 +86,29 @@ fn bench_matmul[MatMul: MatmulSignature]() raises:
             keep(res)
             keep(a)
             keep(b)
-            var g_ops = Float64(dimensions[0] * dimensions[1] * dimensions[2]  * 2) / 1e9
+            var g_ops = Float64(
+                dimensions[0] * dimensions[1] * dimensions[2] * 2
+            ) / 1e9
 
             var op_type: String
             if CurrentDType.is_integral():
                 op_type = "I"
             else:
                 op_type = "F"
-            
-            print("Average G" + op_type + "op/s:" + str(g_ops / report.mean(unit="s")), str(CurrentDType),"dimensions: M=" +  str(dimensions[0]) + ", N=" +  str(dimensions[1]) + ", K=" +  str(dimensions[2]))
+
+            print(
+                "Average G"
+                + op_type
+                + "op/s:"
+                + str(g_ops / report.mean(unit="s")),
+                str(CurrentDType),
+                "dimensions: M="
+                + str(dimensions[0])
+                + ", N="
+                + str(dimensions[1])
+                + ", K="
+                + str(dimensions[2]),
+            )
 
 
 fn keep(res: Matrix):

--- a/July2024/src/test.mojo
+++ b/July2024/src/test.mojo
@@ -18,6 +18,9 @@ alias SCENARIOS = [
 ]
 
 
+#alias DTypesToTest = Tuple[DType.int8, DType.int16, DType.int32, DType.int64, DType.float16, DType.float32, DType.float64]
+
+
 fn basic_matmul[Type: DType, M: Int, N: Int, K: Int, //](inout res: Matrix[Type, M, N], a: Matrix[Type, M, K], b: Matrix[Type, K, N]):    
     for m in range(M):
         for k in range(K):

--- a/July2024/src/test.mojo
+++ b/July2024/src/test.mojo
@@ -1,8 +1,7 @@
 from testing import assert_almost_equal
-from benchmark import clobber_memory
+import benchmark
 from algorithm import vectorize
 from time import now
-import benchmark
 
 alias SCENARIOS = List(
     InlineArray[Int, 3](1, 1, 1),
@@ -81,6 +80,7 @@ fn bench_matmul[MatMul: MatmulSignature]() raises:
                 # of the matmul operation.
                 MatMul(res, a, b)
 
+            benchmark.clobber_memory()
             var report = benchmark.run[matmul_this]()
 
             keep(res)

--- a/July2024/src/test.mojo
+++ b/July2024/src/test.mojo
@@ -18,7 +18,7 @@ alias SCENARIOS = [
 ]
 
 
-#alias DTypesToTest = Tuple[DType.int8, DType.int16, DType.int32, DType.int64, DType.float16, DType.float32, DType.float64]
+alias dtypes_to_test = List[DType](DType.int8, DType.int16, DType.int32, DType.int64,DType.float16, DType.float32, DType.float64)
 
 
 fn basic_matmul[Type: DType, M: Int, N: Int, K: Int, //](inout res: Matrix[Type, M, N], a: Matrix[Type, M, K], b: Matrix[Type, K, N]):    
@@ -51,25 +51,29 @@ fn test_matmul[MatMul: MatmulSignature]() raises:
 
 
 fn bench_matmul[MatMul: MatmulSignature]() raises:
-    var res = Matrix[Type, TestSize, TestSize]()
-    var a = Matrix[Type, TestSize, TestSize].rand()
-    var b = Matrix[Type, TestSize, TestSize].rand()
 
-    var start: Int
-    var end: Int
-    var t: Float64 = 0
+    @parameter
+    for i in range(len(dtypes_to_test)):
+        alias CurrentDType = dtypes_to_test[i]
+        var res = Matrix[CurrentDType, TestSize, TestSize]()
+        var a = Matrix[CurrentDType, TestSize, TestSize].rand()
+        var b = Matrix[CurrentDType, TestSize, TestSize].rand()
 
-    for _ in range(BenchIters):
-        clobber_memory()
+        var start: Int
+        var end: Int
+        var t: Float64 = 0
 
-        start = now()
-        MatMul(res, a, b)
-        end = now()
+        for _ in range(BenchIters):
+            clobber_memory()
 
-        var GFlops = TestSize ** 3 * 2 / (end - start)
-        t += GFlops
-        print("GFlop/s:", GFlops)
+            start = now()
+            MatMul(res, a, b)
+            end = now()
 
-        memset_zero[Type](res.data, res.Elements)
-    
-    print("Average GFlop/s:", t / BenchIters)
+            var GFlops = TestSize ** 3 * 2 / (end - start)
+            t += GFlops
+            print("GFlop/s:", GFlops)
+
+            memset_zero[CurrentDType](res.data, res.Elements)
+        
+        print("Average GFlop/s:", t / BenchIters, str(CurrentDType))


### PR DESCRIPTION
Here is what the performance report look like now: 

```
✅ Passed test with M = 1 , N = 1 , K = 1
✅ Passed test with M = 1 , N = 47 , K = 97
✅ Passed test with M = 53 , N = 1 , K = 101
✅ Passed test with M = 17 , N = 59 , K = 103
✅ Passed test with M = 1024 , N = 1024 , K = 1024
✅ Passed test with M = 256 , N = 1024 , K = 4096
✅ Passed test with M = 256 , N = 4096 , K = 1024
✅ Passed test with M = 128 , N = 3072 , K = 768
✅ Passed test with M = 1024 , N = 2560 , K = 1024
✅ Passed test with M = 1024 , N = 512 , K = 256
✅ Passed test with M = 1024 , N = 1024 , K = 512
Average GIop/s:4.5730382303016812 int8 dimensions: M=1, N=47, K=97
Average GIop/s:4.1880867245238793 int8 dimensions: M=53, N=1, K=101
Average GIop/s:4.6187873496006429 int8 dimensions: M=17, N=59, K=103
Average GIop/s:4.6519654514145676 int8 dimensions: M=1024, N=1024, K=1024
Average GIop/s:4.6177355596342462 int8 dimensions: M=256, N=1024, K=4096
Average GIop/s:4.5439070619518569 int8 dimensions: M=256, N=4096, K=1024
Average GIop/s:4.5741127716433203 int8 dimensions: M=128, N=3072, K=768
Average GIop/s:4.5815512692469289 int8 dimensions: M=1024, N=2560, K=1024
Average GIop/s:4.4927586597614972 int8 dimensions: M=1024, N=512, K=256
Average GIop/s:4.5562718562153135 int8 dimensions: M=1024, N=1024, K=512
Average GIop/s:4.4887266405556705 int16 dimensions: M=1, N=47, K=97
Average GIop/s:4.7487888481096459 int16 dimensions: M=53, N=1, K=101
Average GIop/s:4.562302189581918 int16 dimensions: M=17, N=59, K=103
Average GIop/s:4.6242222806394375 int16 dimensions: M=1024, N=1024, K=1024
Average GIop/s:4.4859439797316929 int16 dimensions: M=256, N=1024, K=4096
Average GIop/s:4.3540916811013428 int16 dimensions: M=256, N=4096, K=1024
Average GIop/s:4.4342101665747737 int16 dimensions: M=128, N=3072, K=768
Average GIop/s:4.4888064055479937 int16 dimensions: M=1024, N=2560, K=1024
Average GIop/s:4.3580981833116708 int16 dimensions: M=1024, N=512, K=256
Average GIop/s:4.5196114706379351 int16 dimensions: M=1024, N=1024, K=512
Average GIop/s:4.5441546543195201 int32 dimensions: M=1, N=47, K=97
Average GIop/s:4.7785862140273725 int32 dimensions: M=53, N=1, K=101
...
```
It runs the benchmark for all combinaison of sizes and dtypes. It's because it's possible that some algorithms perform better on certain dtypes or sizes, and all of them should be taken into account when measuring.

We also use the benchmark tool provided in the stdlib for better accuracy.

Note that the compilation time is greatly increased because of this as the double for loop means many things have to be re-compiled. On my machine the compilation time is around 1 minute.

A good follow-up would be to output bar charts with matplotlib in a specific directory.

I recommend "squash and merge" when merging this to avoid putting all my commits in main.