### PR TITLE
Eliminate the bias on the K dimension

### DIFF
--- a/July2024/src/test.mojo
+++ b/July2024/src/test.mojo
@@ -10,11 +10,13 @@ alias SCENARIOS = InlineArray[size=10](
     InlineArray[size=3](53, 1, 101), 
     InlineArray[size=3](17, 59, 103), 
     InlineArray[size=3](128, 128, 128), 
-    InlineArray[size=3](128, 3072, 768), 
-    InlineArray[size=3](512, 512, 512), 
-    InlineArray[size=3](256, 1024, 4096), 
-    InlineArray[size=3](1024, 1024, 1024), 
-    InlineArray[size=3](4096, 4096, 8192)
+    InlineArray[size=3](210, 210, 210), 
+    InlineArray[size=3](345, 345, 345), 
+    InlineArray[size=3](565, 565, 565), 
+    InlineArray[size=3](927, 927, 927), 
+    InlineArray[size=3](1522, 1522, 1522),
+    InlineArray[size=3](2497, 2497, 2497),
+    InlineArray[size=3](4096, 4096, 4096),
 )
 alias TYPES = InlineArray[size=7](DType.int8, DType.int16, DType.int32, DType.int64, DType.float16, DType.float32, DType.float64)
 


### PR DESCRIPTION
This PR introduces eight data points, logarithmically spaced between 128 and 4096.

A few notes on evaluation: For the same problem size, the peak GFlops for Float32 is naturally twice that of Float64. An algorithm optimized for Float32 will show amplified performance when computing the average GFlops. Therefore, performance should be measured by how quickly it approaches the peak GFlops as the problem size increases.